### PR TITLE
create user-credentials command

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,4 +1,4 @@
-package cmd
+package config
 
 import (
 	"github.com/spf13/cobra"

--- a/cmd/config/set-context.go
+++ b/cmd/config/set-context.go
@@ -1,4 +1,4 @@
-package cmd
+package config
 
 import (
 	"bufio"
@@ -20,9 +20,9 @@ var password string
 
 func NewSetContextCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set-context",
-		Short: "set context info",
-		Long:  "Able to set context info by using this command",
+		Use:   "set-credentials",
+		Short: "set credential info",
+		Long:  "Able to set credentials info by using this command",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			zap.S().Info(args)
@@ -36,7 +36,7 @@ func NewSetContextCmd() *cobra.Command {
 	return cmd
 }
 
-func setLoginInfo(context string) error {
+func setLoginInfo(credentialID string) error {
 	if username == "" {
 		fmt.Print("login user: ")
 		stdin := bufio.NewScanner(os.Stdin)
@@ -52,8 +52,8 @@ func setLoginInfo(context string) error {
 		password = string(bytePassword)
 	}
 	basic := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
-	viper.Set(fmt.Sprintf("context.%s.userID", context), username)
-	viper.Set(fmt.Sprintf("context.%s.basicAuth", context), basic)
+	viper.Set(config.UserID(credentialID), username)
+	viper.Set(config.BasicAuth(credentialID), basic)
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/spf13/cobra"
+	configCmd "github.com/yuichi10/jiractl/cmd/config"
 	"github.com/yuichi10/jiractl/config"
 )
 
@@ -25,7 +26,7 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 	cobra.OnInitialize(initConfig)
-	cmd.AddCommand(NewConfigCmd())
+	cmd.AddCommand(configCmd.NewConfigCmd())
 	return cmd
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,18 @@ type Config struct {
 	CurrentContext string `yaml:"currentContext"`
 }
 
+func CurrentContext() string {
+	return "currentContext"
+}
+
+func UserID(credentialID string) string {
+	return fmt.Sprintf("credentials.%s.userID", credentialID)
+}
+
+func BasicAuth(credentialID string) string {
+	return fmt.Sprintf("credentials.%s.basicAuth", credentialID)
+}
+
 // LoadConfig load config file. If there is no config file
 // this create new config file
 func LoadConfig() error {


### PR DESCRIPTION
## 概要
kubectl と同じように、user, cluster contextを分けて設定するようにする

## 変更内容
前回までset-contextにしていたものをset-credentialsにした