### PR TITLE
able to use detail option

### DIFF
--- a/cmd/sprint/issues.go
+++ b/cmd/sprint/issues.go
@@ -18,7 +18,7 @@ func NewIssueCmd(format string, iapi api.IAPI, ds database.IDataStore, viewer pr
 		Short: "list sprint related issues",
 		Long:  "get sprint issues",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			controller.GetSprintIssue(board, sprint, format, iapi, ds, viewer)
+			controller.GetSprintIssue(board, sprint, format, detail, iapi, ds, viewer)
 			return nil
 		},
 	}

--- a/cmd/sprint/issues.go
+++ b/cmd/sprint/issues.go
@@ -10,6 +10,7 @@ import (
 
 var board string
 var sprint string
+var detail bool
 
 func NewIssueCmd(format string, iapi api.IAPI, ds database.IDataStore, viewer presenter.Viewer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -21,6 +22,7 @@ func NewIssueCmd(format string, iapi api.IAPI, ds database.IDataStore, viewer pr
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&detail, "detail", false, "show detail data")
 	cmd.Flags().StringVarP(&board, "board", "b", "", "set board name")
 	cmd.Flags().StringVarP(&sprint, "sprint", "s", "", "set sprint name. If you do not set, you got active sprint issues")
 	return cmd

--- a/interface/controller/sprint.go
+++ b/interface/controller/sprint.go
@@ -10,6 +10,7 @@ import (
 type SprintIssueInput struct {
 	Board  string
 	Sprint string
+	Detail bool
 }
 
 func (input SprintIssueInput) GetBoardName() string {
@@ -20,11 +21,16 @@ func (input SprintIssueInput) GetSprintName() string {
 	return input.Sprint
 }
 
-func GetSprintIssue(board, sprint, format string, iapi api.IAPI, ds database.IDataStore, viewer presenter.Viewer) {
+func (input SprintIssueInput) RequireDetail() bool {
+	return input.Detail
+}
+
+func GetSprintIssue(board, sprint, format string, detail bool, iapi api.IAPI, ds database.IDataStore, viewer presenter.Viewer) {
 	input := SprintIssueInput{Board: board, Sprint: sprint}
 	a := api.NewJiraAPI(iapi)
 	db := database.NewConfig(ds)
 	p := presenter.NewSprintPresenter(viewer, format)
+
 	// call usecase
 	usecase.GetSprintIssues(input, a, db, p)
 }

--- a/interface/controller/sprint.go
+++ b/interface/controller/sprint.go
@@ -26,7 +26,7 @@ func (input SprintIssueInput) RequireDetail() bool {
 }
 
 func GetSprintIssue(board, sprint, format string, detail bool, iapi api.IAPI, ds database.IDataStore, viewer presenter.Viewer) {
-	input := SprintIssueInput{Board: board, Sprint: sprint}
+	input := SprintIssueInput{Board: board, Sprint: sprint, Detail: detail}
 	a := api.NewJiraAPI(iapi)
 	db := database.NewConfig(ds)
 	p := presenter.NewSprintPresenter(viewer, format)

--- a/interface/presenter/issuePresenter.go
+++ b/interface/presenter/issuePresenter.go
@@ -22,12 +22,12 @@ func NewSprintPresenter(v Viewer, format string) SprintPresenter {
 func (ip SprintPresenter) IssuePresent(out usecase.IssuesOutput, format string, detail bool) {
 	humble := Lines{}
 	if format == "markdown" {
-		humble = markdownIssuePresenter(out)
+		humble = markdownIssuePresenter(out, detail)
 	}
 	ip.View.Show(humble)
 }
 
-func markdownIssuePresenter(out usecase.IssuesOutput) Lines {
+func markdownIssuePresenter(out usecase.IssuesOutput, detail bool) Lines {
 	humble := make(Lines, 0, 50)
 	sort.SliceStable(out, func(i, j int) bool { return out[i].Status < out[j].Status })
 	sort.SliceStable(out, func(i, j int) bool {
@@ -39,7 +39,11 @@ func markdownIssuePresenter(out usecase.IssuesOutput) Lines {
 	var issueOnce sync.Once
 	for _, issue := range out {
 		l := &Line{}
-		l.Body = fmt.Sprintf("[%s](%s) %s %s", issue.Summary, issue.URL, issue.Status, issue.Assignee)
+		if detail {
+			l.Body = fmt.Sprintf("[%s](%s) %s %s", issue.Summary, issue.URL, issue.Status, issue.Assignee)
+		} else {
+			l.Body = fmt.Sprintf("[%s][%s]", issue.Summary, issue.URL)
+		}
 		l.Delimiter = "\n"
 		if issue.IssueType == "ストーリー" || issue.IssueType == "Story" {
 			storyOnce.Do(func() { humble = append(humble, &Line{Body: "Story", Color: "97", Delimiter: "\n"}) })

--- a/interface/presenter/issuePresenter.go
+++ b/interface/presenter/issuePresenter.go
@@ -12,13 +12,14 @@ import (
 type SprintPresenter struct {
 	View   Viewer
 	Format string
+	Detail bool
 }
 
 func NewSprintPresenter(v Viewer, format string) SprintPresenter {
 	return SprintPresenter{View: v, Format: format}
 }
 
-func (ip SprintPresenter) IssuePresent(out usecase.IssuesOutput, format string) {
+func (ip SprintPresenter) IssuePresent(out usecase.IssuesOutput, format string, detail bool) {
 	humble := Lines{}
 	if format == "markdown" {
 		humble = markdownIssuePresenter(out)

--- a/usecase/presenter.go
+++ b/usecase/presenter.go
@@ -22,5 +22,5 @@ type IssueOutput struct {
 type IssuesOutput []*IssueOutput
 
 type IIssuePresenter interface {
-	IssuePresent(out IssuesOutput, format string)
+	IssuePresent(out IssuesOutput, format string, detail bool)
 }

--- a/usecase/sprint.go
+++ b/usecase/sprint.go
@@ -9,6 +9,7 @@ import (
 type ISprintIssuesInput interface {
 	GetBoardName() string
 	GetSprintName() string
+	RequireDetail() bool
 }
 
 // GetSprintIssues get apis
@@ -43,5 +44,5 @@ func GetSprintIssues(input ISprintIssuesInput, api IJiraAPIAccess, db ICurrentCo
 		}
 		output = append(output, o)
 	}
-	presenter.IssuePresent(output, "markdown")
+	presenter.IssuePresent(output, "markdown", input.RequireDetail())
 }


### PR DESCRIPTION
## 概要
sprint issue コマンドに`--detail`オプションをつけることで詳細を見せるようにした。
`--detail`がない場合は、summary + urlのみがひょうじされる。

```
./jiractl sprint isseus --detail
```

## 変更内容
- `detail`オプションの追加